### PR TITLE
jy commit

### DIFF
--- a/src/main/java/com/example/sjhealthy/controller/CommentConroller.java
+++ b/src/main/java/com/example/sjhealthy/controller/CommentConroller.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import javax.xml.stream.events.Comment;
 import java.util.List;
 
 @Controller
@@ -22,6 +23,7 @@ public class CommentConroller {
     public ResponseEntity save(@ModelAttribute CommentDTO commentDTO){
         System.out.println("commentDTO="+commentDTO);
         Long saveResult = commentService.save(commentDTO);
+
         if(saveResult != null){
             //작성 성공
             //다시 댓글 전체를 가지고 와서 보여주기(리턴)

--- a/src/main/java/com/example/sjhealthy/controller/member/LoginController.java
+++ b/src/main/java/com/example/sjhealthy/controller/member/LoginController.java
@@ -1,13 +1,26 @@
 package com.example.sjhealthy.controller.member;
 
+import com.example.sjhealthy.dto.GoogleProfile;
 import com.example.sjhealthy.dto.MemberDTO;
+import com.example.sjhealthy.dto.OAuthToken;
 import com.example.sjhealthy.service.MailServiceImpl;
 import com.example.sjhealthy.service.MemberService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @RequestMapping("/sjhealthy/")
@@ -47,6 +60,109 @@ public class LoginController {
             System.out.println("시스템 오류");
             return "redirect:/sjhealthy";
         }
+    }
+
+    @GetMapping("/member/login/oauth/google")
+    public String OAuthGoogle(String code, HttpServletRequest request, RedirectAttributes ra, Model model) throws JsonProcessingException {
+        OAuthToken token = getAccessTokenWithGoogle(code, request);
+        System.out.println("토큰 " + token);
+        GoogleProfile profile = requestGoogleAccountProfile(token);
+        System.out.println(profile);
+
+        try {
+            MemberDTO isExist = memberService.findMemberEmail(profile.getEmail());
+            if (isExist != null){
+                // 기존 회원이라면 로그인으로 연결
+                ra.addFlashAttribute("memberDTO", isExist);
+                return "redirect:/sjhealthy/member/login";
+            } else {
+                // 비회원은 가입창으로 연결
+                // 회원정보를 가져와 회원가입 뷰로 보냄
+                MemberDTO googleAccount = new MemberDTO();
+                googleAccount.setMemberId(profile.getEmail().split("@")[0]); // 이메일의 @ 앞부분을 가져와 memberId로 설정
+                googleAccount.setMemberEmail(profile.getEmail());
+                googleAccount.setMemberName(profile.getName());
+                model.addAttribute("memberDTO", googleAccount); // 이 3가지 정보를 회원가입 창에 채워서 뷰 출력
+                return "join";
+            }
+
+        } catch (Exception e){
+            System.out.println("시스템 오류");
+            return "redirect:/sjhealthy/member/login";
+        }
+    }
+
+    public OAuthToken getAccessTokenWithGoogle(String code, HttpServletRequest request){
+        System.out.println(code);
+        // 받아온 인가 코드로 액세스 토큰 요청
+        // POST 방식으로 key-value 데이터를 요청하고 액세스 토큰 받아옴
+        RestTemplate rt = new RestTemplate();
+
+        // Headers
+        org.springframework.http.HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // Body
+        String client_id = "175299406832-n5iv92o1fdmg2b7nfqvb4qrh44p7hni8.apps.googleusercontent.com";
+        String client_secret = "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";
+        String redirect_uri = "http://localhost:8081/sjhealthy/member/login/oauth/google";
+        String grant_type = "authorization_code";
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("client_id", client_id);
+        params.add("client_secret", client_secret);
+        params.add("redirect_uri", redirect_uri);
+        params.add("grant_type", grant_type);
+
+        // 한 곳에 담는다
+        HttpEntity<MultiValueMap<String, String>> googleTokenRequest = new HttpEntity<>(params, headers);
+
+        ResponseEntity<String> response = rt.exchange(
+            "https://oauth2.googleapis.com/token",
+            HttpMethod.POST,
+            googleTokenRequest,
+            String.class
+        );
+
+        ObjectMapper mapper = new ObjectMapper();
+        OAuthToken token = new OAuthToken();
+
+        try {
+            token = mapper.readValue(response.getBody(), OAuthToken.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        // 토큰을 세션에 저장
+        HttpSession session = request.getSession();
+        session.setAttribute("accessToken_google", token.getAccess_token());
+        System.out.println("token: " + token);
+
+        return token;
+    }
+
+    public GoogleProfile requestGoogleAccountProfile(OAuthToken token) throws JsonProcessingException {
+        // 토큰을 담아 정보 요청
+        RestTemplate rt2 = new RestTemplate();
+
+        HttpHeaders headers1 = new HttpHeaders();
+        // 토큰은 헤더에 숨겨 보낸다
+        headers1.add(HttpHeaders.AUTHORIZATION, "Bearer " + token.getAccess_token());
+
+        HttpEntity<MultiValueMap<String,String>> googleAccountRequest = new HttpEntity<>(headers1);
+        ResponseEntity<String> response = rt2.exchange(
+            "https://www.googleapis.com/userinfo/v2/me",
+            HttpMethod.GET,
+            googleAccountRequest,
+            String.class
+        );
+
+        ObjectMapper mapper = new ObjectMapper();
+        System.out.println(response);
+
+        GoogleProfile profile = mapper.readValue(response.getBody(), GoogleProfile.class);
+        return profile;
     }
 
     @GetMapping("/member/find-id")

--- a/src/main/java/com/example/sjhealthy/dto/GoogleProfile.java
+++ b/src/main/java/com/example/sjhealthy/dto/GoogleProfile.java
@@ -1,0 +1,14 @@
+package com.example.sjhealthy.dto;
+
+import lombok.Data;
+
+@Data
+public class GoogleProfile {
+    private String id;
+    private String email;
+    private boolean verified_email;
+    private String name;
+    private String given_name;
+    private String family_name;
+    private String picture;
+}

--- a/src/main/java/com/example/sjhealthy/dto/OAuthToken.java
+++ b/src/main/java/com/example/sjhealthy/dto/OAuthToken.java
@@ -1,0 +1,12 @@
+package com.example.sjhealthy.dto;
+
+import lombok.Data;
+
+@Data
+public class OAuthToken {
+    private String access_token;
+    private String expires_in;
+    private String scope;
+    private String token_type;
+    private String id_token;
+}

--- a/src/main/java/com/example/sjhealthy/repository/MemberRepository.java
+++ b/src/main/java/com/example/sjhealthy/repository/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<MemberEntity, String> {
     Optional<MemberEntity> findByMemberId(String memberId);
 
     Optional<MemberEntity> findByMemberNameAndMemberBirth(String memberName, String memberBirth);
+
+    Optional<MemberEntity> findByMemberEmail(String memberEmail);
 }

--- a/src/main/java/com/example/sjhealthy/service/CommentService.java
+++ b/src/main/java/com/example/sjhealthy/service/CommentService.java
@@ -37,7 +37,7 @@ public class CommentService {
     }
 
     public List<CommentDTO> findAll(Long boardId) {
-        // select * from comment_table where 1 = 1  and board_id=? order by id desc;
+        // select from comment_table where 1 = 1  and board_id=? order by id desc;
         BoardEntity boardEntity = boardRepository.findById(boardId).get();
         List<CommentEntity> commentEntityList = commentRepository.findAllByBoardEntityOrderByIdDesc(boardEntity);
         /* EntityList -> DTOList */

--- a/src/main/java/com/example/sjhealthy/service/MemberService.java
+++ b/src/main/java/com/example/sjhealthy/service/MemberService.java
@@ -75,4 +75,12 @@ public class MemberService {
         } else return null;
     }
 
+    public MemberDTO findMemberEmail(String memberEmail){
+        Optional<MemberEntity> byMemberEmail = memberRepository.findByMemberEmail(memberEmail);
+
+        if (byMemberEmail.isPresent()){
+            MemberEntity memberEntity = byMemberEmail.get();
+            return MemberMapper.toMemberDTO(memberEntity);
+        } else return null;
+    }
 }

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>LoginForm</title>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 </head>
 <body>
     <h1>로그인</h1>
@@ -11,7 +12,25 @@
         비밀번호: <input type="password" name="memberPassword">
         <input type="submit" name="submit" value="로그인">
     </form>
+    <button id="googleOAuth">구글 로그인</button>
     <a href="../member/find-id"><button>아이디 찾기</button></a>
     <a href="../member/find-password"><button>비밀번호 찾기</button></a>
+
+<script>
+    document.addEventListener("DOMContentLoaded", ()=> {
+        const google = document.getElementById("googleOAuth");
+        const client_id = "175299406832-n5iv92o1fdmg2b7nfqvb4qrh44p7hni8.apps.googleusercontent.com";
+        const redirect_uri = "http://localhost:8081/sjhealthy/member/login/oauth/google";
+
+        google.addEventListener("click", async (e)=>{
+            e.preventDefault();
+
+            const url = "https://accounts.google.com/o/oauth2/v2/auth?client_id=" + client_id
+                + "&redirect_uri=" + redirect_uri
+                + "&response_type=code&scope=email+profile"; // scope 에 요청 정보
+            window.location.href = url; // 로그인 페이지로 리다이렉트
+    });
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
구글 api 로그인 연동

수연아 구글 로그인 연동할 때 기존 회원이면 바로 로그인으로 연결하는데
회원이 아닐 때 회원가입폼으로 넘어가게 해놨는데
그때 memberDTO라는 이름으로 객체를 뷰로 보냈거든(model로)
그거 너가 만든 join 폼 수정해서 연결해줄 수 있니
memberName, memberId, memberEmail 이 3가지가 회원가입 칸에 채워지고 수정 불가능으로 바뀌면 좋겠어
나머지 폼만 채워서 회원가입 하는 걸로 하면 좋을 것 같은데
어떻게 생각해
