### PR TITLE
jy commit

### DIFF
--- a/src/main/java/com/example/sjhealthy/dto/Response.java
+++ b/src/main/java/com/example/sjhealthy/dto/Response.java
@@ -12,8 +12,16 @@ public class Response<T> { // data 필드를 제네릭으로 받아서 어떠한
     private String message;
     private Long likeCount;
     private Long dislikeCount;
+    private T data2; // 추천게시판에서 관리자 확인 때만 쓰려고
 
     public Response(T data, String message){ // 보통 사용. 4개 다 쓰는 건 Rec 게시판 상세페이지에서만
-        this(data, message, 0L, 0L);
+        this(data, message, 0L, 0L, null);
+    }
+
+    public Response(T data, String message, Long likeCount, Long dislikeCount){
+        this(data, message, likeCount, dislikeCount, null);
+    }
+    public Response(T data, T data2, String message){ // 관리자 확인 때만 쓸 것임
+        this(data, message, 0L, 0L, data2);
     }
 }

--- a/src/main/resources/static/js/adminPage.js
+++ b/src/main/resources/static/js/adminPage.js
@@ -110,26 +110,27 @@
 
         function deleteMember(index, memberId){
             // 회원 탈퇴 버튼
-            const deleteMemberBtn = document.getElementById("deleteMemberBtn"+index);
-
-            deleteMemberBtn.addEventListener("click", async (e)=> {
-                if (!window.confirm("정말로 삭제하시겠습니까?")){
-                    e.preventDefault();
-                    return false;
-                }
-
-                try {
-                    const response = await fetch("/sjhealthy/admin/member/delete/" + memberId);
-                    const data = await response.json();
-
-                    if (!data){
-                        alert(data.message);
-                    } else {
-                        alert(data.message);
-                        loadMemberData(currentPage);
+            const deleteMemberBtn = "deleteMemberBtn" + index; 
+            document.addEventListener("click", async (e) => {
+                if (e.target.id === deleteMemberBtn){
+                    if (!window.confirm("정말로 삭제하시겠습니까?")){
+                        e.preventDefault();
+                        return false;
                     }
-                } catch(error){
-                    console.log("Error = " + error);
+
+                    try {
+                        const response = await fetch("/sjhealthy/admin/member/delete/" + memberId);
+                        const data = await response.json();
+
+                        if (!data){
+                            alert(data.message);
+                        } else {
+                            alert(data.message);
+                            loadMemberData(currentPage);
+                        }
+                    } catch(error){
+                        console.log("Error = " + error);
+                    }
                 }
             });
         }
@@ -188,10 +189,11 @@
                         const deleteBtn = document.createElement("input");
                         // deleteCell.className = "adminButton";
                         deleteBtn.type = "button";
-                        deleteBtn.id = "deletePostBtn"+index;
+                        deleteBtn.id = "deletePostBtn"+ board.boardId;
                         deleteBtn.className = "adminButton";
                         deleteBtn.value = "삭제";
-                        deleteBtn.onclick = (e) => deletePost(index, board.boardId);
+                        deleteBtn.onclick = () => deletePost(index, board.boardId);
+                        
                         deleteCell.appendChild(deleteBtn);
                         // row.append(deleteCell);
 
@@ -252,7 +254,7 @@
                 
                 pageButton.addEventListener("click", (e) => {
                     loadBoardData(i); // 클릭한 페이지 데이터 요청하고 html 생성
-                    currentPage = i; // 클릭한 페이지를 현재 페이지로 저장
+                    window.currentPage = i; // 클릭한 페이지를 현재 페이지로 저장
                 });
                 pagination.appendChild(pageButton); 
             }
@@ -260,27 +262,27 @@
         // 게시물 삭제 버튼
         function deletePost(index, boardId){
             // const deletePosts = document.querySelectorAll(".deletePost");
-            const deleteBtn = document.getElementById("deletePostBtn"+index);
-
-            deleteBtn.addEventListener("click", async (e)=> {
-                if (!window.confirm("정말로 삭제하시겠습니까?")){
-                    e.preventDefault();
-                    return false;
-                }
-
-                try {
-                    const response = await fetch("/sjhealthy/board/delete/"+boardId);
-                    const data = await response.json();
-    
-                    if (response.ok){
-                        alert(data.message);
-                        loadBoardData(currentPage);
+            const deleteB = "deletePostBtn" + boardId; 
+            document.addEventListener("click", async (e) => {
+                if (e.target.id === deleteB){
+                    if (!window.confirm("정말로 삭제하시겠습니까?")){
+                        e.preventDefault();
+                        return false;
                     }
 
-                } catch (error){
-                    alert(data.message);
+                    try {
+                        const response = await fetch("/sjhealthy/board/delete/"+boardId);
+                        const data = await response.json();
+        
+                        if (response.ok){
+                            alert(data.message);
+                            loadBoardData(window.currentPage);
+                        }
+
+                    } catch (error){
+                        alert("시스템 오류로 실패하였습니다.");
+                    }
                 }
             });
-
         }
     });

--- a/src/main/resources/templates/board/list.html
+++ b/src/main/resources/templates/board/list.html
@@ -84,24 +84,52 @@
             </tr>
         </tbody>
     </table>
+
 </div>
 
 <div class="text-center mt-4" id="pagination"></div>
 
 <div class="text-center mt-4">
-    <a href="/sjhealthy/board/write"><button class="btn btn-custom">글 작성</button></a>
+    <a href="/sjhealthy/board/write"><button id="writeBtn" class="btn btn-custom">글 작성</button></a>
     <a href="/sjhealthy"><button class="btn btn-secondary">홈</button></a>
 </div>
 
 </main>
 <script>
     document.addEventListener("DOMContentLoaded", () => {
+        // 글 작성/수정하면서 리다이렉트한 메시지 띄움
+        const message = /*[[${message}]]*/'';
+        if (message) {
+            alert(message);
+        }
+        
+        // 작성 버튼은 회원 전용 기능
+        const loginId = /*[[${loginId}]]*/"";
+        const writeBtn = document.getElementById("writeBtn");
+        writeBtn.addEventListener("click", (e) => {
+            if (!loginId){
+                alert("글은 회원만 작성할 수 있습니다.");
+                e.preventDefault();
+            }
+        });
+
         const boardDiv = document.getElementById("content");
 
         // 게시글 관리
         let currentPage = 1;
         const pageSize = 10;
         
+        // 만약 서버에서 보낸 페이지가 있다면 그걸로 사용
+        const pageBefore = /*[[${page}]]*/'';
+        if (pageBefore){
+            currentPage = pageBefore;
+        } else if (localStorage.getItem("boardPage")){
+            // 목록, 수정, 삭제 버튼 눌러서 왔을 땐 해당 글의 페이지로 이동
+            currentPage = localStorage.getItem("boardPage") ? parseInt(localStorage.getItem("boardPage")) : currentPage;
+            localStorage.clear(); // 앞으로의 사용을 위해 페이지 저장을 초기화 해줌.
+        }
+
+
         // 페이지 열면 자동으로 로드(1페이지로)
         loadBoardData(currentPage);
 
@@ -109,14 +137,17 @@
         async function loadBoardData(page){
             const boardListDiv = document.getElementById("content");
             content.innerHTML = ""; // 기존 내용 비움
-            
+
+            // 목록 버튼 눌러서 왔을 땐 해당 글의 페이지로 이동
             try {
                 // 페이지 누를 때마다 해당 페이지의 게시글 10개를 요청해 받음
                 const response = await fetch("/sjhealthy/board/list?page=" + page);
-
-                const data = await response.json();
                 
-                if (response.status === 200){
+                if (response.status === 204){
+                    alert("게시글이 존재하지 않습니다.");
+                }
+                else if (response.ok){
+                    const data = await response.json();
                     boardListDiv.innerHTML = ""; // 기존 내용 초기화
                     
                     const boardList = data._embedded.boardDTOList;
@@ -153,7 +184,7 @@
                         row.appendChild(postNumber);
 
                         const title = document.createElement("td");
-                        title.innerHTML = `<a href="/sjhealthy/board/read?boardId=${board.boardId}">${board.boardTitle}</a>`;
+                        title.innerHTML = `<a href="/sjhealthy/board/read?boardId=${board.boardId}&page=${page}">${board.boardTitle}</a>`;
                         row.appendChild(title);
 
                         const writer = document.createElement("td");

--- a/src/main/resources/templates/board/read.html
+++ b/src/main/resources/templates/board/read.html
@@ -85,15 +85,15 @@
                 <hr>
 
                 <div class="text-center">
-                    <a th:if="${boardDTO.memberId == loginId}" th:href="@{../board/update?boardId={id}(id=${boardDTO.boardId})}" style="text-decoration: none;">
+                    <a id="update" th:if="${boardDTO.memberId == loginId}" style="text-decoration: none;">
                         <button class="btn btn-primary">수정</button>
                     </a>
 
-                    <a th:if="${boardDTO.memberId == loginId || admin == 'A'}" th:href="@{../board/delete?boardId={id}(id=${boardDTO.boardId})}" style="text-decoration: none;">
+                    <a th:if="${boardDTO.memberId == loginId || admin == 'A'}" th:href="@{../board/delete?boardId={id}&page={page}(id=${boardDTO.boardId}, page=${page})}" style="text-decoration: none;">
                         <button class="btn btn-primary" id="deleteButton">삭제</button>
                     </a>
 
-                    <a href="../board" class="btn btn-secondary" style="text-decoration: none;">목록</a>
+                    <a id="list" class="btn btn-secondary" style="text-decoration: none;">목록</a>
                 </div>
 
                 <!-- 댓글 작성 부분 -->
@@ -133,15 +133,37 @@
 <!--<script th:inline="javascript" th:src="@{/js/board.js}"></script>--><!-- js 분리 -->
 <script th:inline="javascript">
     document.addEventListener("DOMContentLoaded", ()=> {
-        const message = [[${message}]];
+        // 글 작성/수정하면서 리다이렉트한 메시지 띄움
+        const message = /*[[${message}]]*/'';
         if (message) {
             alert(message);
         }
+
+        const list = document.getElementById("list");
+        const update = document.getElementById("update");
+        const page = /*[[${page}]]*/"1";
+        const boardId = /*[[${boardDTO.boardId}]]*/""
+        
+        // 목록 버튼 누르면 페이지 저장해서 경로 이동
+        list.addEventListener("click", () => {
+            if (!localStorage.getItem("boardPage")){ // 기존에 수정 버튼 눌러서 저장된 값이 없을 경우에만 새로 저장
+                localStorage.setItem("boardPage", page); // 로컬에 저장해서 board/list로 요청 보낼 때 쓸 거다
+            }
+            window.location.href = "/sjhealthy/board";
+        });
+
+        // 수정 버튼 누르면 페이지 저장해서 경로 이동
+        update.addEventListener("click", () => {
+            localStorage.setItem("boardPage", page);
+            window.location.href="/sjhealthy/board/update?boardId=" + boardId + "&page=" + page;
+        });
+
 
         const deleteBtn = document.getElementById("deleteButton");
 
         if (deleteBtn){
             deleteBtn.addEventListener("click", (e)=> {
+                localStorage.setItem("boardPage", page); // 로컬에 저장해서 board/list로 요청 보낼 때 쓸 거다
 
                 if (!window.confirm('정말로 삭제하시겠습니까?')){
                     e.preventDefault(); // 취소시 이벤트 발생 없음
@@ -161,24 +183,6 @@
 
                 const imageUrl = "/uploads/files/" + fileName;
                 attachedImage.src = imageUrl;
-
-                // try {
-                //     if (fileName){
-                //         const response = await fetch("/sjhealthy/uploads/files/" + fileName);
-                //         if (!response.ok){
-                //             //console.log("첨부된 파일이 없습니다.");
-                //         } else {
-                //             const data = await response.text();
-
-                //             // URL로 변환하여 src로
-                //             //.log("경로 " + data);
-                //             attachedImage.src = data;
-                //             // img.src = data;
-                //         }
-                //     }
-                // } catch(error){
-                //     //console.log(error);
-                // }
             }
         }
     });
@@ -251,47 +255,6 @@
         }
     }
 </script>
-
-<!-- 이거 나머지는 댓글 삭제에 쓰자
-<script>
-document.addEventListener("DOMContentLoaded", ()=> {
-    const deleteBtn = document.getElementById("deleteButton");
-
-    if (deleteBtn){
-        deleteBtn.addEventListener("click", async (e)=> {
-            try{
-                if (!window.confirm('정말로 삭제하시겠습니까?')){
-                    event.preventDefault(); // 취소시 이벤트 발생 없음
-                    return false;
-                }
-
-                // 삭제하려는 게시물 ID 가져오기
-                const boardId = document.getElementById("boardId").value;
-
-                // 삭제 요청 보내기
-                const response = await fetch("../board/delete", {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({
-                        boardId: boardId
-                    })
-                });
-
-                if (response.ok){
-                    alert("게시물이 삭제되었습니다.");
-                    window.location.href= "../board/list"
-                } else {
-                    alert("게시물 삭제에 실패했습니다.");
-                }
-            } catch (error){
-                console.log('오류 발생:', error);
-            }
-        });
-    }
-});
-</script> -->
 <div th:replace="~{fragment/footer :: main-foot}"></div>
 
 </body>

--- a/src/main/resources/templates/board/write.html
+++ b/src/main/resources/templates/board/write.html
@@ -92,7 +92,7 @@
                 <span th:text="${isUpdate} ? '커뮤니티 수정' : '커뮤니티 작성'"></span>
             </div>
             <div class="card-body">
-                <form class="boardForm" th:action="${isUpdate} != null ? '/sjhealthy/board/update?boardId=' + ${isUpdate.boardId} : '/sjhealthy/board/write'"
+                <form class="boardForm" th:action="${isUpdate} != null ? '/sjhealthy/board/update?boardId=' + ${isUpdate.boardId} + '&page=' + ${page} : '/sjhealthy/board/write'"
                       th:object="${isUpdate != null ? isUpdate : new com.example.sjhealthy.dto.BoardDTO()}" method="POST"
                       enctype="multipart/form-data">
                     <div class="form-row">
@@ -142,11 +142,6 @@
                 $("#boardTitle").focus();
                 e.preventDefault();  // 폼 제출을 막음
                 return;
-            } else if (!content){
-                // 내용이 비어있을 경우 추가 검증 (필요 시)
-                alert("내용을 입력해 주세요.");
-                $("#boardContent").focus();
-                e.preventDefault();
             }
 
             // 수정일 때
@@ -164,43 +159,10 @@
                 }
             }
         });
+
+        const listBtn = document.getElementById("listBtn");
     });
 </script>
-<!-- <script>
-    // 이거 submit이 안 돼서 그냥 required 속성 넣음
-    document.addEventListener("DOMContentLoaded", () => {
-        const submitBtn = document.getElementById("submit");
-        const form = document.querySelector(".boardForm");
-
-        if (submitBtn){
-            submitBtn.addEventListener("click", (e) => {
-                e.preventDefault();
-                const title = document.getElementById("boardTitle").value;
-                const content = document.getElementById("boardContent").value;
-                const writer = document.getElementById("boardWriter").value;
-
-                if (!title){
-                    alert("제목을 입력해 주세요.");
-                } else if (!content){
-                    alert("내용을 입력해 주세요.");
-                } else {
-                    console.log("제출");
-                    // form.submit(); // 폼을 제출. 안 되네;
-                    form.submit();
-                    // submitBtn.click(); // submit 버튼 트리거
-
-                    // 페이지 이동은 검증 로직 밑에.
-                    // 근데 서버에서 로그인 상태 걸러서 필요없다
-                    // if (!writer){ // 로그인 하지 않은 상태일 땐 리스트로 보냄
-                    //     alert("로그인 후 이용해 주세요.");
-                    //     window.location.href = "/sjhealthy/board/list";
-                    // }
-                }
-
-            });
-        }
-    });
-</script> -->
 <div th:replace="~{fragment/footer :: main-foot}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -412,7 +412,6 @@
     
             try {
                 const response = await fetch("/sjhealthy/board/current");
-                const data = await response.json();
                 
                 if (response.status === 204){
                     // 게시글이 존재하지 않을 때
@@ -421,6 +420,7 @@
                     board.appendChild(li);
                     //console.log(data.message);
                 } else if (response.ok){
+                    const data = await response.json();
                     //console.log(data);
                     const boardList = data.data;
 

--- a/src/main/resources/templates/recommend/recList.html
+++ b/src/main/resources/templates/recommend/recList.html
@@ -176,7 +176,6 @@
 
 <div>
     <input type="hidden" th:value="${loginId}" id="loginId">
-    <input type="hidden" th:value="${administrator}" id="admin">
     <!-- th:text는 html 요소의 텍스트 내용을 설정. 따라서 value로 읽으려면 th:value로 해야 한다 -->
 </div>
 


### PR DESCRIPTION
-커뮤니티
작성된 글 없으면 "게시글이 존재하지 않습니다" alert 메시지
제목만 필수값 입력으로 받기
글 작성 완료하면 글이 작성되었습니다 alert 메시지
게시글 작성, 수정, 삭제 등에서 발생하는 메시지를
list로 리다이렉트 했을 때 alert 창으로 출력

비회원이 작성 버튼 누르면 “글은 회원만 작성할 수 있습니다.” alert 
(로그인 페이지로 연결 삭제)
비회원이 수정 버튼 누르면 "로그인 후 이용해 주세요." alert -> board로 이동

js로 페이지 이동할 때 링크가 .../board?boardId=%&page=% 형식으로 일정하도록 변경
글 삭제, 수정, 목록 버튼 클릭 시, 이전 페이지로 이동하도록 변경

-메인
작성된 글 없으면 "게시글이 존재하지 않습니다" alert 메시지

-추천
추천게시판 상세보기는 회원만 조회 가능
변환할 때 memberId 필요해서 그렇게 바꿈

관리자일 때 상세보기 + 삭제버튼 뜨고
회원일 때 삭제버튼 안 뜨고 상세보기는 되고
비회원일 때 상세보기도 안 되게 설정

삭제할 때 confirm 메시지 추가
삭제버튼 2번 눌러야 인식하는 문제 수정
   - 페이지 로딩 후 버튼이 동적으로 추가되면 getElementById로 찾을 수 없다
     event.target.id === "deleteB"
     이렇게 '이벤트위임'을 해야한다

글 삭제 시, 이전 페이지로 이동

-관리자 기능
삭제버튼 2번 눌러야 인식하는 문제 수정
회원관리와 게시물관리 페이지네이션 분리
게시글 삭제 시, 이전 페이지로 이동
삭제버튼 동적 할당에서 index 대신 boardId 사용




--------------------할 거
추천게시판 검색 기능 페이지네이션 중에서 서버쪽 수정 필요

